### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [0.3.0] - 2018-10-03
+
+### Add
+
+* Add `--once` option [#15](https://github.com/yuya-takeyama/circleci-queue-to-datadog/pull/15)
+
 ## [0.2.0] - 2018-09-24
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ docker run -e CIRCLECI_API_TOKEN=<CircleCI API Token> -e DATADOG_API_KEY=<Data
 ### Kubernetes
 
 ```
-$ kubectl run circleci-queue-to-datadog --image=yuyat/circleci-queue-to-datadog:0.2.0 --env CIRCLECI_API_TOKEN=<CircleCI API Token> --env DATADOG_API_KEY=<Datadog API Key>
+$ kubectl run circleci-queue-to-datadog --image=yuyat/circleci-queue-to-datadog:0.3.0 --env CIRCLECI_API_TOKEN=<CircleCI API Token> --env DATADOG_API_KEY=<Datadog API Key>
 ```
 
 ## Options

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package main
 
-const version string = "0.2.0"
+const version string = "0.3.0"
 
 var gitCommit = ""


### PR DESCRIPTION
## [0.3.0] - 2018-10-03

### Add

* Add `--once` option [#15](https://github.com/yuya-takeyama/circleci-queue-to-datadog/pull/15)